### PR TITLE
using sh to make alpine images work

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
             - "3000:443"
         environment:
             - NGINX_HOST=${NGINX_HOST}
-        command: /bin/bash -c "envsubst '$$NGINX_HOST' < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
+        command: /bin/sh -c "envsubst '$$NGINX_HOST' < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
         restart: always
         depends_on:
             - php


### PR DESCRIPTION
Alpine does not come with bash installed, so "command" should use sh to be compatible with the alpine version of nginx images.